### PR TITLE
tag key added to serialize method in alarms.py

### DIFF
--- a/rackio/alarms.py
+++ b/rackio/alarms.py
@@ -51,8 +51,9 @@ class Alarm:
 
         result = dict()
         
-        result["name"] = self._name
-        result["state"] = self._state
+        result["name"] = self.get_name()
+        result["tag"] = self.get_tag()
+        result["state"] = self.get_state()
         result["enabled"] = self._enabled
         result["process"] = self._process
         result["triggered"] = self._triggered

--- a/rackio/alarms.py
+++ b/rackio/alarms.py
@@ -266,6 +266,14 @@ class AlarmManager:
 
         return
 
+    def get_alarm_by_tag(self, tag):
+
+        for _alarm in self._alarms:
+            if tag == _alarm.get_tag():
+                return _alarm
+
+        return
+
     def get_alarms(self):
 
         result = list()
@@ -274,6 +282,7 @@ class AlarmManager:
             result.append(_alarm)
 
         return result
+
 
     def alarm_tags(self):
 

--- a/rackio/alarms.py
+++ b/rackio/alarms.py
@@ -54,8 +54,9 @@ class Alarm:
 
         result = dict()
         
-        result["name"] = self._name
-        result["state"] = self._state
+        result["name"] = self.get_name()
+        result["tag"] = self.get_tag()
+        result["state"] = self.get_state()
         result["enabled"] = self._enabled
         result["process"] = self._process
         result["triggered"] = self._triggered

--- a/rackio/alarms.py
+++ b/rackio/alarms.py
@@ -334,5 +334,3 @@ class AlarmManager:
             if tag == _alarm.get_tag():
 
                 _alarm.update(value)
-    
->>>>>>> cfd891eb9e3c541da43fc6dabe1e21d41f2534fb

--- a/rackio/core.py
+++ b/rackio/core.py
@@ -281,6 +281,17 @@ class Rackio(Singleton):
 
         return alarm
 
+    def get_alarm_by_tag(self, tag):
+        """Returns a Alarm defined by its tag.
+
+        # Parameters
+        tag (str): an alarm tag.
+        """
+
+        alarm = self._alarm_manager.get_alarm_by_tag(tag)
+
+        return alarm
+
     def append_machine(self, machine, interval=1):
         """Append a state machine to the state machine manager.
         

--- a/rackio/managers/alarms.py
+++ b/rackio/managers/alarms.py
@@ -32,6 +32,14 @@ class AlarmManager:
 
         return
 
+    def get_alarm_by_tag(self, tag):
+
+        for _alarm in self._alarms:
+            if tag == _alarm.get_tag():
+                return _alarm
+
+        return
+
     def get_alarms(self):
 
         result = list()


### PR DESCRIPTION
Hello Nelson, I need in my project a method to get tag name of an alarm. I was doing with alarm.serialize()['tag'] but this key doesn't exist in the dict, so I added to rackio core, and I modified in that section result["name"] = self._name to result["name] = self.get_name().

Then, I checked there is a method in alarm with name alarm.get_tag(), it's simpler but I already done the change.